### PR TITLE
Improve LifeGroups Page

### DIFF
--- a/lifegroups.html
+++ b/lifegroups.html
@@ -146,6 +146,13 @@
     </section>
     <section class="section">
       <div class="container is-readable">
+        <div class="notification">
+          <h3 class="title is-size-3">Looking for LifeGroup specifics?</h3>
+            The fastest way to find information like meeting times, locations, and whether childcare is provided is to use the Newsong App.<br/>
+            <p class="has-text-right">
+              <a class="button is-primary is-outlined is-medium has-text-weight-bold" href="http://subsplash.com/newsong/app">Download Our App Now</a>
+            </p>
+        </div>
         <div class="content">
           <p>
             We believe God created us to live in relationship with one another
@@ -165,9 +172,11 @@
           <p>
             Groups usually range from 8 to 15 people and generally meet in a
             host home located throughout the Edwardsville, Glen Carbon, and
-            surrounding areas. You can find specific locations and schedules
-            by <a href="http://subsplash.com/newsong/app">downloading our app</a> or you can send an email to Tim Giltner,
-            <a href="mailto:tgiltner@newsong-fellowship.com?subject=Lifegroups&body=Hi%20Tim%2C%0D%0AI%27d%20like%20to%20know%20more%20about%20Lifegroups.">tgiltner@newsong-fellowship.com</a>
+            surrounding areas.
+          </p>
+          <h3>Interested in you joining a LifeGroup?</h3>
+          <p>
+            Our groups are open, so you're always welcome to show up! If you would prefer to talk to someone about what group might be a good fit, you can <a href="mailto:tgiltner@newsong-fellowship.com?subject=Lifegroups&body=Hi%20Tim%2C%0D%0AI%27d%20like%20to%20know%20more%20about%20Lifegroups">send an email to Pastor Tim Giltner</a> (tgiltner@newsong-fellowship.com).
           </p>
         </div>
       </div>


### PR DESCRIPTION
Fixes https://trello.com/c/uyTjEKlO/69-lifegroups

Here are the reasons:

 - We don't confuse our communication strategy
 - We don't have to update information in multiple different places
 - We make the call to action for the app more prominent
 - At the very top of the page, we address the issue of people not knowing where to go to find that information. And the call to action is now a button, instead of a text link. 
 - We separate the option to email Tim, which helps improve its discoverability.

