### PR TITLE
Editable link blocks

### DIFF
--- a/_data/links.yml
+++ b/_data/links.yml
@@ -1,4 +1,4 @@
-link-blocks:
+blocks:
   - text: What to Expect
     image: /public/img/what-to-expect-small.jpg
     link: what-to-expect.html

--- a/_data/links.yml
+++ b/_data/links.yml
@@ -1,40 +1,41 @@
-- text: What to Expect
-  image: /public/img/what-to-expect-small.jpg
-  link: what-to-expect.html
-  layout: image-block
-- text: Our Services
-  image: /public/img/living-room-communion-side-hug-small.jpg
-  link: our-services.html
-  layout: image-block
-- text: What we Believe
-  image: /public/img/what-we-believe-small.jpg
-  link: what-we-believe.html
-  layout: image-block
-- text: Our Team
-  image: /public/img/living-room-preaching-small.jpg
-  link: our-team.html
-  layout: image-block
-- text: Sensory City
-  image:
-  link: sensory.html
-  layout: image-block
-- text: Next Steps
-  image: /public/img/living-room-cello-small.jpg
-  link: next-steps.html
-  layout: image-block
-- text: LifeGroups
-  image: /public/img/living-room-families-small.jpg
-  link: lifegroups.html
-  layout: image-block
-- text: Past Sermons
-  image: /public/img/living-room-dave-preaching-small.jpg
-  link: past-sermons.html
-  layout: image-block
-- text: Current Series
-  image:
-  link: current-series.html
-  layout: custom-embed
-- text: What we Mean By<br />LOVE WINS
-  image:
-  link: love-wins.html
-  layout: solid-black
+blocks:
+  - text: What to Expect
+    image: /public/img/what-to-expect-small.jpg
+    link: what-to-expect.html
+    layout: image-block
+  - text: Our Services
+    image: /public/img/living-room-communion-side-hug-small.jpg
+    link: our-services.html
+    layout: image-block
+  - text: What we Believe
+    image: /public/img/what-we-believe-small.jpg
+    link: what-we-believe.html
+    layout: image-block
+  - text: Our Team
+    image: /public/img/living-room-preaching-small.jpg
+    link: our-team.html
+    layout: image-block
+  - text: Sensory City
+    image:
+    link: sensory.html
+    layout: image-block
+  - text: Next Steps
+    image: /public/img/living-room-cello-small.jpg
+    link: next-steps.html
+    layout: image-block
+  - text: LifeGroups
+    image: /public/img/living-room-families-small.jpg
+    link: lifegroups.html
+    layout: image-block
+  - text: Past Sermons
+    image: /public/img/living-room-dave-preaching-small.jpg
+    link: past-sermons.html
+    layout: image-block
+  - text: Current Series
+    image:
+    link: current-series.html
+    layout: custom-embed
+  - text: What we Mean By<br />LOVE WINS
+    image:
+    link: love-wins.html
+    layout: solid-black

--- a/_data/links.yml
+++ b/_data/links.yml
@@ -38,4 +38,4 @@ blocks:
   - text: What we Mean By<br />LOVE WINS
     image:
     link: love-wins.html
-    layout: solid-color
+    layout: solid-black

--- a/_data/links.yml
+++ b/_data/links.yml
@@ -1,4 +1,4 @@
-blocks:
+link-blocks:
   - text: What to Expect
     image: /public/img/what-to-expect-small.jpg
     link: what-to-expect.html

--- a/_data/links.yml
+++ b/_data/links.yml
@@ -1,0 +1,41 @@
+blocks:
+  - text: What to Expect
+    image: /public/img/what-to-expect-small.jpg
+    link: what-to-expect.html
+    layout: image-block
+  - text: Our Services
+    image: /public/img/living-room-communion-side-hug-small.jpg
+    link: our-services.html
+    layout: image-block
+  - text: What we Believe
+    image: /public/img/what-we-believe-small.jpg
+    link: what-we-believe.html
+    layout: image-block
+  - text: Our Team
+    image: /public/img/living-room-preaching-small.jpg
+    link: our-team.html
+    layout: image-block
+  - text: Sensory City
+    image:
+    link: sensory.html
+    layout: image-block
+  - text: Next Steps
+    image: /public/img/living-room-cello-small.jpg
+    link: next-steps.html
+    layout: image-block
+  - text: LifeGroups
+    image: /public/img/living-room-families-small.jpg
+    link: lifegroups.html
+    layout: image-block
+  - text: Past Sermons
+    image: /public/img/living-room-dave-preaching-small.jpg
+    link: past-sermons.html
+    layout: image-block
+  - text: Current Series
+    image:
+    link: current-series.html
+    layout: custom-embed
+  - text: What we Mean By<br />LOVE WINS
+    image:
+    link: love-wins.html
+    layout: solid-color

--- a/_data/links.yml
+++ b/_data/links.yml
@@ -1,41 +1,41 @@
 blocks:
-  - text: What to Expect
+  - title: What to Expect
     image: /public/img/what-to-expect-small.jpg
     link: what-to-expect.html
     layout: image-block
-  - text: Our Services
+  - title: Our Services
     image: /public/img/living-room-communion-side-hug-small.jpg
     link: our-services.html
     layout: image-block
-  - text: What we Believe
+  - title: What we Believe
     image: /public/img/what-we-believe-small.jpg
     link: what-we-believe.html
     layout: image-block
-  - text: Our Team
+  - title: Our Team
     image: /public/img/living-room-preaching-small.jpg
     link: our-team.html
     layout: image-block
-  - text: Sensory City
+  - title: Sensory City
     image:
     link: sensory.html
     layout: image-block
-  - text: Next Steps
+  - title: Next Steps
     image: /public/img/living-room-cello-small.jpg
     link: next-steps.html
     layout: image-block
-  - text: LifeGroups
+  - title: LifeGroups
     image: /public/img/living-room-families-small.jpg
     link: lifegroups.html
     layout: image-block
-  - text: Past Sermons
+  - title: Past Sermons
     image: /public/img/living-room-dave-preaching-small.jpg
     link: past-sermons.html
     layout: image-block
-  - text: Current Series
+  - title: Current Series
     image:
     link: current-series.html
     layout: custom-embed
-  - text: What we Mean By<br />LOVE WINS
+  - title: What we Mean By<br />LOVE WINS
     image:
     link: love-wins.html
     layout: solid-black

--- a/_data/links.yml
+++ b/_data/links.yml
@@ -1,41 +1,40 @@
-blocks:
-  - text: What to Expect
-    image: /public/img/what-to-expect-small.jpg
-    link: what-to-expect.html
-    layout: image-block
-  - text: Our Services
-    image: /public/img/living-room-communion-side-hug-small.jpg
-    link: our-services.html
-    layout: image-block
-  - text: What we Believe
-    image: /public/img/what-we-believe-small.jpg
-    link: what-we-believe.html
-    layout: image-block
-  - text: Our Team
-    image: /public/img/living-room-preaching-small.jpg
-    link: our-team.html
-    layout: image-block
-  - text: Sensory City
-    image:
-    link: sensory.html
-    layout: image-block
-  - text: Next Steps
-    image: /public/img/living-room-cello-small.jpg
-    link: next-steps.html
-    layout: image-block
-  - text: LifeGroups
-    image: /public/img/living-room-families-small.jpg
-    link: lifegroups.html
-    layout: image-block
-  - text: Past Sermons
-    image: /public/img/living-room-dave-preaching-small.jpg
-    link: past-sermons.html
-    layout: image-block
-  - text: Current Series
-    image:
-    link: current-series.html
-    layout: custom-embed
-  - text: What we Mean By<br />LOVE WINS
-    image:
-    link: love-wins.html
-    layout: solid-black
+- text: What to Expect
+  image: /public/img/what-to-expect-small.jpg
+  link: what-to-expect.html
+  layout: image-block
+- text: Our Services
+  image: /public/img/living-room-communion-side-hug-small.jpg
+  link: our-services.html
+  layout: image-block
+- text: What we Believe
+  image: /public/img/what-we-believe-small.jpg
+  link: what-we-believe.html
+  layout: image-block
+- text: Our Team
+  image: /public/img/living-room-preaching-small.jpg
+  link: our-team.html
+  layout: image-block
+- text: Sensory City
+  image:
+  link: sensory.html
+  layout: image-block
+- text: Next Steps
+  image: /public/img/living-room-cello-small.jpg
+  link: next-steps.html
+  layout: image-block
+- text: LifeGroups
+  image: /public/img/living-room-families-small.jpg
+  link: lifegroups.html
+  layout: image-block
+- text: Past Sermons
+  image: /public/img/living-room-dave-preaching-small.jpg
+  link: past-sermons.html
+  layout: image-block
+- text: Current Series
+  image:
+  link: current-series.html
+  layout: custom-embed
+- text: What we Mean By<br />LOVE WINS
+  image:
+  link: love-wins.html
+  layout: solid-black

--- a/_includes/page_link.html
+++ b/_includes/page_link.html
@@ -1,60 +1,26 @@
-{% case include.link %}
-  {% when "what-we-believe.html" %}
-    <a href="/what-we-believe.html" class="tile-button has-bg-image is-square-tablet" style="background-image: url(/public/img/what-we-believe-small.jpg);">
-      <div class="tile-button-inner">
-        <div class="button is-light is-outlined is-medium has-text-weight-bold">What we Believe</div>
-      </div>
-    </a>
-  {% when "what-to-expect.html" %}
-    <a href="/what-to-expect.html" class="tile-button has-bg-image is-square-tablet" style="background-image: url(/public/img/what-to-expect-small.jpg);">
-      <div class="tile-button-inner">
-        <div class="button is-light is-outlined is-medium has-text-weight-bold">What to Expect</div>
-      </div>
-    </a>
-  {% when "our-services.html" %}
-    <a href="/our-services.html" class="tile-button has-bg-image is-square-tablet" style="background-image: url(/public/img/living-room-communion-side-hug-small.jpg);">
-      <div class="tile-button-inner">
-        <div class="button is-light is-outlined is-medium has-text-weight-bold">Our Services</div>
-      </div>
-    </a>
-  {% when "next-steps.html" %}
-    <a href="/next-steps.html" class="tile-button has-bg-image is-square-tablet" style="background-image: url(/public/img/living-room-cello-small.jpg);">
-      <div class="tile-button-inner">
-        <div class="button is-light is-outlined is-medium has-text-weight-bold">Next Steps</div>
-      </div>
-    </a>
-  {% when "past-sermons.html" %}
-    <a href="/past-sermons.html" class="tile-button has-bg-image is-square-tablet" style="background-image: url(/public/img/living-room-dave-preaching-small.jpg);">
-      <div class="tile-button-inner">
-        <div class="button is-light is-outlined is-medium has-text-weight-bold">Past Sermons</div>
-      </div>
-    </a>
-  {% when "current-series.html" %}
-    <a href="/current-series.html" class="tile-button has-iframe-image is-square-tablet">
-      <div class="tile-button-inner">
-        <iframe title="Current Series Image" src="https://subsplash.com/+f947/embed/mi/*?video" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-        <div class="tile-button-iframe-cover"></div>
-        <div class="button is-light is-outlined is-medium has-text-weight-bold">Current Series</div>
-      </div>
-    </a>
-  {% when "love-wins.html" %}
-    <a href="/love-wins.html" class="tile-button has-two-line-button is-black is-square-tablet">
-      <div class="tile-button-inner">
-        <div class="button is-multiline is-light is-outlined is-medium has-text-weight-bold">What we Mean By<br />LOVE WINS</div>
-      </div>
-    </a>
-  {% when "lifegroups.html" %}
-    <a href="/lifegroups.html" class="tile-button has-bg-image is-square-tablet" style="background-image: url(/public/img/living-room-families-small.jpg);">
-      <div class="tile-button-inner">
-        <div class="button is-light is-outlined is-medium has-text-weight-bold">LifeGroups</div>
-      </div>
-    </a>
-  {% when "our-team.html" %}
-    <a href="/our-team.html" class="tile-button has-bg-image is-square-tablet" style="background-image: url(/public/img/living-room-preaching-small.jpg);">
-      <div class="tile-button-inner">
-        <div class="button is-light is-outlined is-medium has-text-weight-bold">Our Team</div>
-      </div>
-    </a>
-  {% else %}
+{% assign linkBlocks = (site.data.links.blocks | where:"link", {{include.link}}) %}
 
-{% endcase %}
+{% for item in linkBlocks  %}
+  {% case item.layout %}
+    {% when "custom-embed" %}
+      <a href="/{{ item.link }}" class="tile-button has-iframe-image is-square-tablet">
+        <div class="tile-button-inner">
+          <iframe title="Current Series Image" src="https://subsplash.com/+f947/embed/mi/*?video" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+          <div class="tile-button-iframe-cover"></div>
+          <div class="button is-light is-outlined is-medium has-text-weight-bold">{{ item.text }}</div>
+        </div>
+      </a>
+    {% when "solid-black" %}
+      <a href="/{{ item.link }}" class="tile-button has-two-line-button is-black is-square-tablet">
+        <div class="tile-button-inner">
+          <div class="button is-multiline is-light is-outlined is-medium has-text-weight-bold">{{ item.text }}</div>
+        </div>
+      </a>
+    {% when "image-block" %}
+      <a href="/{{ item.link }}" class="tile-button has-bg-image is-square-tablet" style="background-image: url({{ item.image }});">
+        <div class="tile-button-inner">
+          <div class="button is-light is-outlined is-medium has-text-weight-bold">{{ item.text }}</div>
+        </div>
+      </a>
+  {% endcase %}
+{% endfor %}

--- a/_includes/page_link.html
+++ b/_includes/page_link.html
@@ -7,19 +7,19 @@
         <div class="tile-button-inner">
           <iframe title="Current Series Image" src="https://subsplash.com/+f947/embed/mi/*?video" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
           <div class="tile-button-iframe-cover"></div>
-          <div class="button is-light is-outlined is-medium has-text-weight-bold">{{ item.text }}</div>
+          <div class="button is-light is-outlined is-medium has-text-weight-bold">{{ item.title }}</div>
         </div>
       </a>
     {% when "solid-black" %}
       <a href="/{{ item.link }}" class="tile-button has-two-line-button is-black is-square-tablet">
         <div class="tile-button-inner">
-          <div class="button is-multiline is-light is-outlined is-medium has-text-weight-bold">{{ item.text }}</div>
+          <div class="button is-multiline is-light is-outlined is-medium has-text-weight-bold">{{ item.title }}</div>
         </div>
       </a>
     {% when "image-block" %}
       <a href="/{{ item.link }}" class="tile-button has-bg-image is-square-tablet" style="background-image: url({{ item.image }});">
         <div class="tile-button-inner">
-          <div class="button is-light is-outlined is-medium has-text-weight-bold">{{ item.text }}</div>
+          <div class="button is-light is-outlined is-medium has-text-weight-bold">{{ item.title }}</div>
         </div>
       </a>
   {% endcase %}

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -81,5 +81,5 @@ collections:
                 widget: 'relation'
                 collection: 'pages'
                 searchFields: ['title', 'path']
-                valueField: '{{slug}}'
+                valueField: 'slug'
                 displayFields: ['title']

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -62,19 +62,23 @@ collections:
         name: 'link-blocks'
         file: '_data/links.yml'
         fields:
-          - label: 'Layout'
-            name: 'layout'
-            widget: 'select'
-            options:
-              - { label: 'Background Image', value: 'image-block' }
-              - { label: 'Custom Subsplash Embed', value: 'custom-embed' }
-              - { label: 'Solid Black', value: 'solid-black' }
-          - {label: 'Text', name: text, widget: string}
-          - {label: 'Image', name: image, widget: image}
-          - label: 'Linked Page'
-            name: 'link'
-            widget: 'relation'
-            collection: 'pages'
-            searchFields: ['title', 'url']
-            valueField: 'url'
-            displayFields: ['title']
+          label: "Link Blocks"
+          name: "blocks"
+          widget: "object"
+          fields:
+            - label: 'Layout'
+              name: 'layout'
+              widget: 'select'
+              options:
+                - { label: 'Background Image', value: 'image-block' }
+                - { label: 'Custom Subsplash Embed', value: 'custom-embed' }
+                - { label: 'Solid Black', value: 'solid-black' }
+            - {label: 'Text', name: text, widget: string}
+            - {label: 'Image', name: image, widget: image}
+            - label: 'Linked Page'
+              name: 'link'
+              widget: 'relation'
+              collection: 'pages'
+              searchFields: ['title', 'url']
+              valueField: 'url'
+              displayFields: ['title']

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -16,27 +16,9 @@ collections:
       - { label: 'Image', name: 'image', widget: 'image' }
       - { label: 'Contains Subsplash Embed', name: 'subsplash-embed', widget: 'boolean' }
       - { label: 'Body', name: 'body', widget: 'markdown' }
-      - label: 'Left Block'
-        name: 'left_link'
-        widget: 'relation'
-        collection: 'links'
-        searchFields: ['title', 'link']
-        valueField: 'link'
-        displayFields: ['title']
-      - label: 'Middle Block'
-        name: 'middle_link'
-        widget: 'relation'
-        collection: 'links'
-        searchFields: ['blocks.title', 'blocks.link']
-        valueField: 'blocks.link'
-        displayFields: ['blocks.title']
-      - label: 'Right Block'
-        name: 'right_link'
-        widget: 'relation'
-        collection: 'links'
-        searchFields: ['title', 'link']
-        valueField: 'link'
-        displayFields: ['title']
+      - { label: 'Left Link', name: 'left_link', widget: 'string', default: 'example.html' }
+      - { label: 'Middle Link', name: 'middle_link', widget: 'string', default: 'example.html' }
+      - { label: 'Right Link', name: 'right_link', widget: 'string', default: 'example.html' }
   - name: 'config'
     label: 'Configuration'
     editor:
@@ -46,7 +28,7 @@ collections:
         name: 'navigation'
         file: '_data/navigation.yml'
         fields:
-          - label: 'Navigation Items'
+          - label: 'Navigation Groups'
             name: 'groups'
             widget: 'list'
             allow_add: false

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -81,5 +81,5 @@ collections:
                 widget: 'relation'
                 collection: 'pages'
                 searchFields: ['title', 'path']
-                valueField: '{{filename}}'
+                valueField: {{filename}}
                 displayFields: ['title']

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -62,23 +62,19 @@ collections:
         name: 'link-blocks'
         file: '_data/links.yml'
         fields:
-          - label: "Link Blocks"
-            name: "blocks"
-            widget: "object"
-            fields:
-              - label: 'Layout'
-                name: 'layout'
-                widget: 'select'
-                options:
-                  - { label: 'Background Image', value: 'image-block' }
-                  - { label: 'Custom Subsplash Embed', value: 'custom-embed' }
-                  - { label: 'Solid Black', value: 'solid-black' }
-              - {label: 'Text', name: text, widget: string}
-              - {label: 'Image', name: image, widget: image}
-              - label: 'Linked Page'
-                name: 'link'
-                widget: 'relation'
-                collection: 'pages'
-                searchFields: ['title', 'url']
-                valueField: 'url'
-                displayFields: ['title']
+          - label: 'Layout'
+            name: 'layout'
+            widget: 'select'
+            options:
+              - { label: 'Background Image', value: 'image-block' }
+              - { label: 'Custom Subsplash Embed', value: 'custom-embed' }
+              - { label: 'Solid Black', value: 'solid-black' }
+          - {label: 'Text', name: text, widget: string}
+          - {label: 'Image', name: image, widget: image}
+          - label: 'Linked Page'
+            name: 'link'
+            widget: 'relation'
+            collection: 'pages'
+            searchFields: ['title', 'url']
+            valueField: 'url'
+            displayFields: ['title']

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -81,5 +81,5 @@ collections:
                 widget: 'relation'
                 collection: 'pages'
                 searchFields: ['title', 'path']
-                valueField: {{filename}}
+                valueField: {{slug}}
                 displayFields: ['title']

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -16,9 +16,27 @@ collections:
       - { label: 'Image', name: 'image', widget: 'image' }
       - { label: 'Contains Subsplash Embed', name: 'subsplash-embed', widget: 'boolean' }
       - { label: 'Body', name: 'body', widget: 'markdown' }
-      - { label: 'Left Link', name: 'left_link', widget: 'string', default: 'example.html' }
-      - { label: 'Middle Link', name: 'middle_link', widget: 'string', default: 'example.html' }
-      - { label: 'Right Link', name: 'right_link', widget: 'string', default: 'example.html' }
+      - label: 'Left Block'
+        name: 'left_link'
+        widget: 'relation'
+        collection: 'pages'
+        searchFields: ['title', 'url']
+        valueField: 'url'
+        displayFields: ['title']
+      - label: 'Middle Block'
+        name: 'middle_link'
+        widget: 'relation'
+        collection: 'pages'
+        searchFields: ['title', 'url']
+        valueField: 'url'
+        displayFields: ['title']
+      - label: 'Right Block'
+        name: 'right_link'
+        widget: 'relation'
+        collection: 'pages'
+        searchFields: ['title', 'url']
+        valueField: 'url'
+        displayFields: ['title']
   - name: 'config'
     label: 'Configuration'
     editor:

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -59,22 +59,26 @@ collections:
                   - {label: 'Name', name: 'title', widget: string}
                   - {label: 'Link', name: 'url', widget: string, default: '/example.html'}
       - label: 'Link Blocks'
-        name: 'link-blocks'
+        name: 'links'
         file: '_data/links.yml'
         fields:
-          - label: 'Layout'
-            name: 'layout'
-            widget: 'select'
-            options:
-              - { label: 'Background Image', value: 'image-block' }
-              - { label: 'Custom Subsplash Embed', value: 'custom-embed' }
-              - { label: 'Solid Black', value: 'solid-black' }
-          - {label: 'Text', name: text, widget: string}
-          - {label: 'Image', name: image, widget: image}
-          - label: 'Linked Page'
-            name: 'link'
-            widget: 'relation'
-            collection: 'pages'
-            searchFields: ['title', 'url']
-            valueField: 'url'
-            displayFields: ['title']
+          - label: 'Link Blocks'
+            name: 'blocks'
+            widget: 'list'
+            fields:
+              - label: 'Layout'
+                name: 'layout'
+                widget: 'select'
+                options:
+                  - { label: 'Background Image', value: 'image-block' }
+                  - { label: 'Custom Subsplash Embed', value: 'custom-embed' }
+                  - { label: 'Solid Black', value: 'solid-black' }
+              - {label: 'Text', name: text, widget: string}
+              - {label: 'Image', name: image, widget: image}
+              - label: 'Linked Page'
+                name: 'link'
+                widget: 'relation'
+                collection: 'pages'
+                searchFields: ['title', 'url']
+                valueField: 'url'
+                displayFields: ['title']

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -19,24 +19,24 @@ collections:
       - label: 'Left Block'
         name: 'left_link'
         widget: 'relation'
-        collection: 'pages'
-        searchFields: ['title', 'url']
-        valueField: 'url'
-        displayFields: ['title']
+        collection: 'links'
+        searchFields: ['text', 'link']
+        valueField: 'link'
+        displayFields: ['text']
       - label: 'Middle Block'
         name: 'middle_link'
         widget: 'relation'
-        collection: 'pages'
-        searchFields: ['title', 'url']
-        valueField: 'url'
-        displayFields: ['title']
+        collection: 'links'
+        searchFields: ['text', 'link']
+        valueField: 'link'
+        displayFields: ['text']
       - label: 'Right Block'
         name: 'right_link'
         widget: 'relation'
-        collection: 'pages'
-        searchFields: ['title', 'url']
-        valueField: 'url'
-        displayFields: ['title']
+        collection: 'links'
+        searchFields: ['text', 'link']
+        valueField: 'link'
+        displayFields: ['text']
   - name: 'config'
     label: 'Configuration'
     editor:
@@ -62,23 +62,19 @@ collections:
         name: 'links'
         file: '_data/links.yml'
         fields:
-          - label: 'Link Blocks'
-            name: 'blocks'
-            widget: 'list'
-            fields:
-              - label: 'Layout'
-                name: 'layout'
-                widget: 'select'
-                options:
-                  - { label: 'Background Image', value: 'image-block' }
-                  - { label: 'Custom Subsplash Embed', value: 'custom-embed' }
-                  - { label: 'Solid Black', value: 'solid-black' }
-              - {label: 'Text', name: text, widget: string}
-              - {label: 'Image', name: image, widget: image}
-              - label: 'Linked Page'
-                name: 'link'
-                widget: 'relation'
-                collection: 'pages'
-                searchFields: ['title', 'url']
-                valueField: 'url'
-                displayFields: ['title']
+          - label: 'Layout'
+            name: 'layout'
+            widget: 'select'
+            options:
+              - { label: 'Background Image', value: 'image-block' }
+              - { label: 'Custom Subsplash Embed', value: 'custom-embed' }
+              - { label: 'Solid Black', value: 'solid-black' }
+          - {label: 'Text', name: text, widget: string}
+          - {label: 'Image', name: image, widget: image}
+          - label: 'Linked Page'
+            name: 'link'
+            widget: 'relation'
+            collection: 'pages'
+            searchFields: ['title', 'url']
+            valueField: 'url'
+            displayFields: ['title']

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -19,8 +19,8 @@ collections:
       - { label: 'Left Link', name: 'left_link', widget: 'string', default: 'example.html' }
       - { label: 'Middle Link', name: 'middle_link', widget: 'string', default: 'example.html' }
       - { label: 'Right Link', name: 'right_link', widget: 'string', default: 'example.html' }
-  - name: 'navigation'
-    label: 'Navigation'
+  - name: 'config'
+    label: 'Configuration'
     editor:
       preview: false
     files:
@@ -56,5 +56,11 @@ collections:
                     - { label: 'Custom Subsplash Embed', value: 'custom-embed' }
                     - { label: 'Solid Black', value: 'solid-black' }
                 - {label: 'Text', name: text, widget: string}
-                - {label: 'Link', name: link, widget: string}
                 - {label: 'Image', name: image, widget: image}
+                - label: 'Linked Page'
+                  name: 'link'
+                  widget: 'relation'
+                  collection: 'pages'
+                  searchFields: ['title', 'url']
+                  valueField: 'url'
+                  displayFields: ['title']

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -27,9 +27,9 @@ collections:
         name: 'middle_link'
         widget: 'relation'
         collection: 'links'
-        searchFields: ['title', 'link']
-        valueField: 'link'
-        displayFields: ['title']
+        searchFields: ['blocks.title', 'blocks.link']
+        valueField: 'blocks.link'
+        displayFields: ['blocks.title']
       - label: 'Right Block'
         name: 'right_link'
         widget: 'relation'
@@ -79,6 +79,6 @@ collections:
                 name: 'link'
                 widget: 'relation'
                 collection: 'pages'
-                searchFields: ['title', 'url']
-                valueField: 'url'
+                searchFields: ['title', 'path']
+                valueField: 'path'
                 displayFields: ['title']

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -53,6 +53,7 @@ collections:
             fields:
               - {label: 'Group Heading', name: 'title', widget: 'string'}
               - label: 'Pages'
+                singular_label: 'Page'
                 name: 'pages'
                 widget: 'list'
                 fields:

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -62,23 +62,23 @@ collections:
         name: 'link-blocks'
         file: '_data/links.yml'
         fields:
-          label: "Link Blocks"
-          name: "blocks"
-          widget: "object"
-          fields:
-            - label: 'Layout'
-              name: 'layout'
-              widget: 'select'
-              options:
-                - { label: 'Background Image', value: 'image-block' }
-                - { label: 'Custom Subsplash Embed', value: 'custom-embed' }
-                - { label: 'Solid Black', value: 'solid-black' }
-            - {label: 'Text', name: text, widget: string}
-            - {label: 'Image', name: image, widget: image}
-            - label: 'Linked Page'
-              name: 'link'
-              widget: 'relation'
-              collection: 'pages'
-              searchFields: ['title', 'url']
-              valueField: 'url'
-              displayFields: ['title']
+          - label: "Link Blocks"
+            name: "blocks"
+            widget: "object"
+            fields:
+              - label: 'Layout'
+                name: 'layout'
+                widget: 'select'
+                options:
+                  - { label: 'Background Image', value: 'image-block' }
+                  - { label: 'Custom Subsplash Embed', value: 'custom-embed' }
+                  - { label: 'Solid Black', value: 'solid-black' }
+              - {label: 'Text', name: text, widget: string}
+              - {label: 'Image', name: image, widget: image}
+              - label: 'Linked Page'
+                name: 'link'
+                widget: 'relation'
+                collection: 'pages'
+                searchFields: ['title', 'url']
+                valueField: 'url'
+                displayFields: ['title']

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -81,5 +81,5 @@ collections:
                 widget: 'relation'
                 collection: 'pages'
                 searchFields: ['title', 'path']
-                valueField: 'path'
+                valueField: '{{filename}}'
                 displayFields: ['title']

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -58,27 +58,27 @@ collections:
                 fields:
                   - {label: 'Name', name: 'title', widget: string}
                   - {label: 'Link', name: 'url', widget: string, default: '/example.html'}
-        - label: 'Link Blocks'
-          name: 'links'
-          file: '_data/links.yml'
-          fields:
-            - label: 'Link Blocks'
-              name: 'blocks'
-              widget: 'list'
-              fields:
-                - label: 'Layout'
-                  name: 'layout'
-                  widget: 'select'
-                  options:
-                    - { label: 'Background Image', value: 'image-block' }
-                    - { label: 'Custom Subsplash Embed', value: 'custom-embed' }
-                    - { label: 'Solid Black', value: 'solid-black' }
-                - {label: 'Text', name: text, widget: string}
-                - {label: 'Image', name: image, widget: image}
-                - label: 'Linked Page'
-                  name: 'link'
-                  widget: 'relation'
-                  collection: 'pages'
-                  searchFields: ['title', 'url']
-                  valueField: 'url'
-                  displayFields: ['title']
+      - label: 'Link Blocks'
+        name: 'links'
+        file: '_data/links.yml'
+        fields:
+          - label: 'Link Blocks'
+            name: 'blocks'
+            widget: 'list'
+            fields:
+              - label: 'Layout'
+                name: 'layout'
+                widget: 'select'
+                options:
+                  - { label: 'Background Image', value: 'image-block' }
+                  - { label: 'Custom Subsplash Embed', value: 'custom-embed' }
+                  - { label: 'Solid Black', value: 'solid-black' }
+              - {label: 'Text', name: text, widget: string}
+              - {label: 'Image', name: image, widget: image}
+              - label: 'Linked Page'
+                name: 'link'
+                widget: 'relation'
+                collection: 'pages'
+                searchFields: ['title', 'url']
+                valueField: 'url'
+                displayFields: ['title']

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -81,5 +81,5 @@ collections:
                 widget: 'relation'
                 collection: 'pages'
                 searchFields: ['title', 'path']
-                valueField: {{slug}}
+                valueField: '{{slug}}'
                 displayFields: ['title']

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -40,3 +40,21 @@ collections:
                 fields:
                   - {label: 'Name', name: 'title', widget: string}
                   - {label: 'Link', name: 'url', widget: string, default: '/example.html'}
+        - label: 'Link Blocks'
+          name: 'links'
+          file: '_data/links.yml'
+          fields:
+            - label: 'Link Blocks'
+              name: 'blocks'
+              widget: 'list'
+              fields:
+                - label: 'Layout'
+                  name: 'layout'
+                  widget: 'select'
+                  options:
+                    - { label: 'Background Image', value: 'image-block' }
+                    - { label: 'Custom Subsplash Embed', value: 'custom-embed' }
+                    - { label: 'Solid Black', value: 'solid-black' }
+                - {label: 'Text', name: text, widget: string}
+                - {label: 'Link', name: link, widget: string}
+                - {label: 'Image', name: image, widget: image}

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -59,7 +59,7 @@ collections:
                   - {label: 'Name', name: 'title', widget: string}
                   - {label: 'Link', name: 'url', widget: string, default: '/example.html'}
       - label: 'Link Blocks'
-        name: 'links'
+        name: 'link-blocks'
         file: '_data/links.yml'
         fields:
           - label: 'Layout'

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -20,23 +20,23 @@ collections:
         name: 'left_link'
         widget: 'relation'
         collection: 'links'
-        searchFields: ['text', 'link']
+        searchFields: ['title', 'link']
         valueField: 'link'
-        displayFields: ['text']
+        displayFields: ['title']
       - label: 'Middle Block'
         name: 'middle_link'
         widget: 'relation'
         collection: 'links'
-        searchFields: ['text', 'link']
+        searchFields: ['title', 'link']
         valueField: 'link'
-        displayFields: ['text']
+        displayFields: ['title']
       - label: 'Right Block'
         name: 'right_link'
         widget: 'relation'
         collection: 'links'
-        searchFields: ['text', 'link']
+        searchFields: ['title', 'link']
         valueField: 'link'
-        displayFields: ['text']
+        displayFields: ['title']
   - name: 'config'
     label: 'Configuration'
     editor:
@@ -73,7 +73,7 @@ collections:
                   - { label: 'Background Image', value: 'image-block' }
                   - { label: 'Custom Subsplash Embed', value: 'custom-embed' }
                   - { label: 'Solid Black', value: 'solid-black' }
-              - {label: 'Text', name: text, widget: string}
+              - {label: 'Text', name: title, widget: string}
               - {label: 'Image', name: image, widget: image}
               - label: 'Linked Page'
                 name: 'link'

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -76,10 +76,4 @@ collections:
                   - { label: 'Solid Black', value: 'solid-black' }
               - {label: 'Text', name: title, widget: string}
               - {label: 'Image', name: image, widget: image}
-              - label: 'Linked Page'
-                name: 'link'
-                widget: 'relation'
-                collection: 'pages'
-                searchFields: ['title', 'path']
-                valueField: 'slug'
-                displayFields: ['title']
+              - {label: 'Link', name: 'link', widget: string, default: 'example.html'}


### PR DESCRIPTION
Fixes #19 

 - In the CMS when adding the left, middle, and right link blocks we use the list of existing pages so you no longer have to type in a URL.
 - In the CMS, you can now setup link blocks! Add new, editing existing, woo hoo!